### PR TITLE
Cover short log entries, and small improvements.

### DIFF
--- a/src/popup/App.vue
+++ b/src/popup/App.vue
@@ -61,7 +61,7 @@
               <md-table-cell class="no-wrap" />
               <md-table-cell />
               <md-table-cell class="no-wrap"><b>TOTAL</b></md-table-cell>
-              <md-table-cell class="no-wrap">{{ formatDuration(totalDuration) }}</md-table-cell>
+              <md-table-cell class="no-wrap">{{ totalDuration() }}</md-table-cell>
               <md-table-cell class="no-wrap" />
             </md-table-row>
           </md-table>
@@ -110,15 +110,6 @@ export default {
       isSaving: false,
       showSnackbar: false
     };
-  },
-  computed: {
-    totalDuration () {
-      let totalDuration = 0;
-      this.logs.forEach(function (log) {
-        totalDuration += log.duration;
-      });
-      return totalDuration;
-    }
   },
   watch: {
     startDate: function (newVal, oldVal) {
@@ -311,6 +302,21 @@ export default {
             _self.errorMessage = typeof (error.response) !== 'undefined' ? error.response.statusText : error.response;
           }
         });
+    },
+    totalDuration () {
+      let _self = this;
+      if (!_self.logs.length) {
+        return 'Loading...';
+      }
+      let totalDuration = 0;
+      _self.logs.forEach(function (log) {
+        if (log.duration) {
+          totalDuration += log.duration;
+        }
+      });
+      if (totalDuration) {
+        return _self.formatDuration(totalDuration);
+      }
     }
   }
 };

--- a/src/popup/App.vue
+++ b/src/popup/App.vue
@@ -91,7 +91,7 @@ import axios from 'axios';
 import moment from 'moment';
 
 const initalStartDate = new Date(moment().startOf('day'));
-const initalEndDate = new Date(moment().add(1, 'days').endOf('day'));
+const initalEndDate = new Date(moment().endOf('day'));
 
 export default {
   data () {
@@ -256,7 +256,7 @@ export default {
     fetchEntries () {
       let _self = this;
       let startDate = moment(this.startDate).utc(true).toISOString(true).replace('+00:00', 'Z');
-      let endDate = moment(this.endDate).utc(true).toISOString(true).replace('+00:00', 'Z');
+      let endDate = moment(this.endDate).add(1, 'days').utc(true).toISOString(true).replace('+00:00', 'Z');
 
       axios.get('https://www.toggl.com/api/v8/time_entries', {
         headers: { Authorization: 'Basic ' + window.btoa(_self.togglApiToken + ':api_token') },

--- a/src/popup/App.vue
+++ b/src/popup/App.vue
@@ -44,7 +44,7 @@
 
             <md-table-row v-for="log in logs" :key="log.id">
               <md-table-cell class="no-wrap">
-                <md-checkbox v-if="log.issue === 'NO ID' || log.isSynced" v-model="checkedLogs" disabled :value="log" />
+                <md-checkbox v-if="log.issue === 'NO ID' || log.isSynced || log.duration < 60" v-model="checkedLogs" disabled :value="log" />
                 <md-checkbox v-else v-model="checkedLogs" :value="log" />
               </md-table-cell>
               <md-table-cell class="no-wrap">{{ log.issue }}</md-table-cell>
@@ -207,6 +207,9 @@ export default {
     },
     formatDuration (duration) {
       duration = Number(duration);
+      if (duration < 60) {
+        return 'Too short';
+      }
       let h = Math.floor(duration / 3600);
       let m = Math.floor(duration % 3600 / 60);
       let hDisplay = h > 0 ? h + 'h' : '';


### PR DESCRIPTION
- Fixes #5 , by adding a "Too short" duration text and disabling the checkbox. It seems to not be possible to log entries shorter than 60s in jira API, so I chose this option rather than filtering them out of the list or rounding them to 1m.
- Fixes TOTAL counter when there are tasks without ID (it would be blank since you would be adding null to totalDuration). It also shows "Loading ..." initially.  
- Makes dates inclusive (I think it what makes the most sense, but it's a separate commit so it's up for discussion)