### PR TITLE
Modify: improve the awaiting

### DIFF
--- a/src/popup/App.vue
+++ b/src/popup/App.vue
@@ -238,7 +238,11 @@ export default {
       const headers = {
         'X-Atlassian-Token': 'no-check', 'User-Agent': ''
       };
+      const awaitingIssues = {};
       for (let log of this.checkedLogs) {
+        if (log.issue in awaitingIssues) {
+          await awaitingIssues[log.issue];
+        }
         const promise = axios({
           method: 'post',
           url:
@@ -263,10 +267,11 @@ export default {
           })
           .catch(function (error) {
             _self.errorMessage = error;
+          })
+          .finally(function () {
+            delete awaitingIssues[log.issue];
           });
-        if (!_self.jiraMerge) {
-          await promise;
-        }
+        awaitingIssues[log.issue] = promise;
       }
     },
     toJiraDateTime (date) {


### PR DESCRIPTION
Hi,
I found my mistake in #28.
If "Merge entries with same description" is enabled, but worklogs has different description with a same issue, multiple posts will be made to a same issue.
The current implementation does not await in such cases.

ex:
TEST-1 xxx 25m
TEST-1 yyy 36m

So I solved it with a way to store the awaiting object.

Please check it😉