### PR TITLE
Request to Toggl api are failing

### DIFF
--- a/src/popup/App.vue
+++ b/src/popup/App.vue
@@ -368,7 +368,7 @@ export default {
         }
         if (typeof log.pid !== 'undefined') {
           axios
-            .get('https://www.toggl.com/api/v8/projects/' + log.pid, {
+            .get('https://api.track.toggl.com/api/v8/projects/' + log.pid, {
               headers: {
                 Authorization:
                   'Basic ' + btoa(_self.togglApiToken + ':api_token')
@@ -410,7 +410,7 @@ export default {
 
       _self.blockFetch = true;
       axios
-        .get('https://www.toggl.com/api/v8/time_entries', {
+        .get('https://api.track.toggl.com/api/v8/time_entries', {
           headers: {
             Authorization: 'Basic ' + btoa(_self.togglApiToken + ':api_token')
           },


### PR DESCRIPTION
Fixes the Toggl API to use the new https://api.track.toggl.com domain