### PR TITLE
Fix loading time for single day with saved dates

### DIFF
--- a/src/popup/App.vue
+++ b/src/popup/App.vue
@@ -395,11 +395,12 @@ export default {
       const timezone = `${sign}${abspad(offset / 60)}:${abspad(offset % 60)}`;
 
       let startDate = moment(this.startDate)
+        .startOf('day')
         .utc(true)
         .toISOString(true)
         .replace('+00:00', timezone);
       let endDate = moment(this.endDate)
-        .add(1, 'days')
+        .endOf('day')
         .utc(true)
         .toISOString(true)
         .replace('+00:00', timezone);


### PR DESCRIPTION
Fetch from beginning of startDate to end of endDate instead of adding a day.