### PR TITLE
Round to Int when calculating timezone offset to allow for 30min offsets

### DIFF
--- a/src/popup/App.vue
+++ b/src/popup/App.vue
@@ -392,7 +392,7 @@ export default {
       const offset = new Date().getTimezoneOffset();
       const sign = offset <= 0 ? '+' : '-';
       function abspad (num) { return ('0' + Math.abs(num)).slice(-2); }
-      const timezone = `${sign}${abspad(offset / 60)}:${abspad(offset % 60)}`;
+      const timezone = `${sign}${abspad(Math.floor(offset / 60))}:${abspad(offset % 60)}`;
 
       let startDate = moment(this.startDate)
         .utc(true)


### PR DESCRIPTION
Fetching toggl entries fails for timezones with 30min offsets as the calculated timezone offset string ends up like 8.5:30  rather than 8:30